### PR TITLE
Fixed non-functional Dockerfile for newer (7.4+) php versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ FROM php:7-apache
 MAINTAINER TheAssassin <theassassin@assassinate-you.net>
 
 RUN apt-get update && \
-    apt-get install -y wget git zip default-libmysqlclient-dev libbz2-dev libmemcached-dev libsasl2-dev libfreetype6-dev libicu-dev libjpeg-dev libmemcachedutil2 libpng-dev libxml2-dev mariadb-client ffmpeg libimage-exiftool-perl python curl python-pip && \
-    docker-php-ext-configure gd --with-freetype-dir=/usr/include --with-jpeg-dir=/usr/include && \
-    docker-php-ext-install -j$(nproc) bcmath bz2 calendar exif gd gettext iconv intl mbstring mysqli opcache pdo_mysql zip && \
+    apt-get install -y wget git zip default-libmysqlclient-dev libbz2-dev libzip-dev libmemcached-dev libsasl2-dev libfreetype6-dev libicu-dev libjpeg-dev libmemcachedutil2 libpng-dev libxml2-dev mariadb-client ffmpeg libimage-exiftool-perl python curl python-pip && \
+    docker-php-ext-configure gd --with-freetype=/usr/include --with-jpeg=/usr/include && \
+    docker-php-ext-install -j$(nproc) bcmath bz2 calendar exif gd gettext iconv intl mysqli opcache pdo_mysql zip && \
     rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* /root/.cache && \
     a2enmod rewrite
 


### PR DESCRIPTION
With update php-7.4 (https://github.com/docker-library/php/pull/910#issuecomment-559383597) the --with-freetype-dir and --with-jpeg-dir were renamed and mbstring does not need to be installed for the php:7-apache image anymore (https://stackoverflow.com/questions/59251008/docker-laravel-configure-error-package-requirements-oniguruma-were-not-m)